### PR TITLE
Fix: termux and internal storage paths issues when relative Path is missing in URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
+# package managers Lock files
 yarn.lock
+pnpm-lock.yaml
+package-lock.json
 dist.zip
 dist/main.js
 dist/main.css

--- a/.vscode/pack-zip.js
+++ b/.vscode/pack-zip.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const jszip = require('jszip');
-const sendFile = require('./sendFile');
+// const sendFile = require('./sendFile');
 
 const iconFile = path.join(__dirname, '../icon.png');
 const pluginJSON = path.join(__dirname, '../plugin.json');

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,9 +1,8 @@
 import { exec } from "child_process";
 import * as esbuild from "esbuild";
 import { sassPlugin } from 'esbuild-sass-plugin'
-
 const isServe = process.argv.includes("--serve");
-
+const servePort = process.argv.find((arg) => arg.includes("--port="))?.split("=")[1] || 3000;
 // Function to pack the ZIP file
 function packZip() {
   exec("node .vscode/pack-zip.js", (err, stdout, stderr) => {
@@ -47,7 +46,7 @@ let buildConfig = {
     await ctx.watch();
     const { host, port } = await ctx.serve({
       servedir: ".",
-      port: 3000,
+      port: parseInt(servePort),
     });
 
   } else {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "acode.plugin.version.control.git",
   "name": "Version Control (Git)",
   "main": "main.js",
-  "version": "1.0.2-dev.10",
+  "version": "1.0.2",
   "readme": "readme.md",
   "icon": "icon.png",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "acode.plugin.version.control.git",
   "name": "Version Control (Git)",
   "main": "main.js",
-  "version": "1.0.2",
+  "version": "1.0.2-dev.10",
   "readme": "readme.md",
   "icon": "icon.png",
   "files": [

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -72,10 +72,12 @@ function resolvePath(...paths: string[]) {
 }
 
 function uriToPath(uri: string): string {
+  console.log("uriToPath", uri);
   if (uri.startsWith('content://com.android.externalstorage.documents/tree/primary')) {
     if (uri.indexOf('::') === -1) {
       let path = decodeURIComponent(uri).split('primary:')[1];
       if (!path.startsWith('/')) path = '/' + path;
+      console.log("uriToPath :: path", path);
       return path;
     }
 
@@ -120,7 +122,7 @@ function pathToUri(path: string): string {
     return termuxUri + path2;
   }
   const segments = path.split("/");
-  const storedGitRepoDir = localStorage.getItem('gitRepoDir')?.replace(/\//g, "%2F") || segments[1];
+  const storedGitRepoDir = localStorage.getItem('gitRepoDir')?.slice(1)?.replace(/\//g, "%2F") || segments[1];
   const relativePath = segments.slice(1).join("/");
   return `content://com.android.externalstorage.documents/tree/primary:${storedGitRepoDir}::primary:${relativePath}`;
 }

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -72,12 +72,11 @@ function resolvePath(...paths: string[]) {
 }
 
 function uriToPath(uri: string): string {
-  console.log("uriToPath", uri);
   if (uri.startsWith('content://com.android.externalstorage.documents/tree/primary')) {
     if (uri.indexOf('::') === -1) {
       let path = decodeURIComponent(uri).split('primary:')[1];
       if (!path.startsWith('/')) path = '/' + path;
-      console.log("uriToPath :: path", path);
+
       return path;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,6 +206,14 @@ class VersionControl {
       if (dir !== this.lastDir) {
         $sourceFileList.innerHTML = '';
         this.lastDir = dir;
+        // Needed for pathToUri operation for knowing exact base Path
+        // the App has access to.
+        // As Android's SAF permissions are hierarchical & scoped.
+        // i.e : `/storage/emulated/0/Android/data/com.termux/files/home/test-repo` permission to this URI would allow
+        // access to it's subdirectories, not out of scope(i.e: `/storage/emulated/0/Android/data/com.termux/files/home`)
+        
+        // Hope this gets executed before IsRepository check - UnschooledGamer.
+        localStorage.setItem("gitRepoDir", dir);
       }
 
       if (!(await this.isRepository(dir))) {
@@ -1020,6 +1028,7 @@ class VersionControl {
   private get currentFolder(): AddedFolder {
     const folders = window.addedFolder;
     if (!folders || folders.length < 1) {
+      localStorage.setItem("gitRepoDir", '')
       throw new NO_FOLDER_SELECTED();
     }
     if (folders.length > 1) {
@@ -1082,6 +1091,7 @@ class VersionControl {
     this.$mainStyle?.remove();
     this.progresIndicator.destroy();
     sidebarApps.remove('vcs-sidebar');
+    localStorage.removeItem('gitRepoDir');
   }
 }
 


### PR DESCRIPTION
# Changes: 

- Stores the `gitRepoDir` in localStorage for later usage in `path.ts`
- Fixes path issues on android internal storage & termux when there is no relative Path in URI
- adds `--port` argument for esbuild serve, usage syntax as "--port=8080"

plugin zip to test:
[dist.zip](https://github.com/user-attachments/files/18374960/dist.zip)

